### PR TITLE
changed the instructions to make it less ambiguous

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ function generateSeed(mnemonic){
 Using this mnemonic as a source of randomness, you can now create signing keypair.
 
 To generate a private key from the hex seed, we will to use the [ethereumjs-wallet library](https://github.com/ethereumjs/ethereumjs-wallet)
+(If you like, explore a much more robust address derivation application at [iancoleman.io](https://iancoleman.io/bip39/))
 ```javascript
 const hdkey = require('ethereumjs-wallet/hdkey')
 ```
 
-__*Explore a much more robust address derivation application at [iancoleman.io](https://iancoleman.io/bip39/)*__
+Below this, insert the function to generate a private key:
 
 ```javascript
 function generatePrivKey(mnemonic){


### PR DESCRIPTION
When I ran this, I thought the "Explore a much more robust address derivation application at iancoleman.io" meant that the code that follows is optional. Turns out it did not mean that of course. But it's understandable I thought that since the previous steps were all instructions followed by code. 

To make things more in line with the precedent, I have moved the "explore ..." line above and added a simple instruction to add the code to the file.

Hope this helps someone else like me